### PR TITLE
correct the createDeriveKey function signature in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ Creates a new hasher instance using the standard hash function.
 
 Creates a new hasher instance for a keyed hash. For more information, see [the blake3 docs](https://docs.rs/blake3/0.1.3/blake3/fn.keyed_hash.html).
 
-##### `createDeriveKey(key: Buffer): Hasher`
+##### `createDeriveKey(context: string): Hasher`
 
 Creates a new hasher instance for the key derivation function. For more information, see [the blake3 docs](https://docs.rs/blake3/0.1.3/blake3/fn.derive_key.html).
 


### PR DESCRIPTION
If I'm reading the code correctly, this function takes a context string, which is definitely the right thing for it to take. But the readme described it as taking a key, maybe because of a paste-o?